### PR TITLE
[1.x] Add patch for drupal/dynamic_entity_reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,5 +4,14 @@
     "type": "metapackage",
     "license": "GPLv2",
     "minimum-stability": "dev",
-    "require": {}
+    "require": {
+        "drupal/dynamic_entity_reference": "^1"
+    },
+    "extra": {
+        "patches": {
+            "drupal/dynamic_entity_reference": {
+                "Issue #3099176: Errors when new entity types are added (in certain cases)": "https://www.drupal.org/files/issues/2022-02-14/3099176-1.x-14.patch"
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Issue requiring the patch
https://www.drupal.org/node/3099176

## Issue 
https://www.drupal.org/project/social/issues/3386004

## Reason for incompatibility
The issue fixes a problem where default settings for field items in the module are not properly applied. However the number of items and the location of the items changes between versions which causes it to be impossible to generate a patch that solves the issue in both versions.

## Link to matching PR for sibling branch in this repository
https://github.com/goalgorilla/open_social_upgrade_patches/pull/2